### PR TITLE
- Fix build.sh failure due to exec command replacing existing shell session

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ echo -n 'import "../css/style.css"
 import "../css/sprite.css"
 ' > $MAIN_JS;
 
-exec node <<EOF
+$(exec node <<EOF
 const { writeFile } = require("fs");
 const config = require("./src/appConfig.js");
 
@@ -30,6 +30,7 @@ export const commentListLimit = \${config.commentListLimit};\`,
   }
 );
 EOF
+);
 
 # Append app.js contents to main.js
 # app.js is the main module for our frontend js


### PR DESCRIPTION
Exec command in build.sh replaces the existing shell session with the node shell. Once completed, session exited without executing the rest of the bash script. Used command substitution to work around the problem.