### PR TITLE
Static file caching, improved rollup config and build.sh, fixes

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,3 @@
-import { resolve } from "path";
 import terser from "@rollup/plugin-terser";
 import postcss from "rollup-plugin-postcss";
 import autoprefixer from "autoprefixer";
@@ -16,7 +15,6 @@ let additionalFiles = readdirSync("src/public/images")
   .map((file) => `dist/${file}`);
 
 additionalFiles = additionalFiles.concat([
-  "dist/bundle.min.css",
   "dist/bulma.min.css",
   "dist/swipe.min.js",
   "dist/purify.min.js",
@@ -29,11 +27,12 @@ const brotliPromise = promisify(brotliCompress);
 const gzipFilter = /.(js|css|png|svg|ico|xml|json)$/;
 
 export default {
-  input: ["./src/public/js/bundle.min.js", "./src/public/js/admin.min.js"],
+  input: ["./src/public/js/bundle.js", "./src/public/js/admin.js"],
   output: {
     sourcemap: true,
     dir: "dist",
     format: "es",
+    entryFileNames: "[hash].[name].min.js",
     generatedCode: {
       constBindings: true,
     },
@@ -53,7 +52,9 @@ export default {
   },
   plugins: [
     postcss({
-      extract: resolve("./dist/bundle.min.css"),
+      extract: true,
+      minimize: true,
+      sourceMap: false,
       plugins: [autoprefixer(), cssnano()],
     }),
     copy({

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -18,8 +18,11 @@ const config = {
   static: {
     enableBrotli: true,
     index: false,
-    extensions: ["js", "css", "png", "svg"],
+    extensions: ["js", "css", "png", "svg", "xml", "json"],
   },
+
+  // used to send cache control headers
+  staticFileExt: ["css", "js", "svg", "xml", "json", "png", "ico"],
 
   // cors
   corsOption: {

--- a/src/middleware/cacheHeaders.js
+++ b/src/middleware/cacheHeaders.js
@@ -1,0 +1,8 @@
+module.exports = (req, res, next) => {
+  const ext = req.path.split(".").at(-1);
+
+  if (res.app.locals.staticFileExt.includes(ext)) {
+    res.set("Cache-Control", "public, max-age=31536000");
+  }
+  next();
+};

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -487,7 +487,7 @@ async function getProductCategories(db) {
     },
     {
       $sort: {
-        category: -1,
+        _id: -1,
       },
     },
   ]);

--- a/src/server.js
+++ b/src/server.js
@@ -27,6 +27,7 @@ app.locals.shopListLimit = config.shopListLimit;
 app.locals.commentListLimit = config.commentListLimit;
 app.locals.pwdInputs = config.pwdInputs;
 app.locals.imgUrl = config.imgUrl;
+app.locals.staticFileExt = config.staticFileExt;
 
 app.set("views", join(__dirname, "views"));
 app.set("view engine", "ejs");
@@ -82,7 +83,11 @@ config.session.store = MongoStore.create({
 if (process.env.NODE_ENV === "production") {
   app.set("trust proxy", 1); // trust first proxy
   config.session.cookie.secure = true;
-  app.use("/", serveCompressed("public", "public", config.static));
+  app.use(
+    "/",
+    require(join(__dirname, "middleware", "cacheHeaders.js")),
+    serveCompressed("public", "public", config.static)
+  );
 } else {
   app.use(express.static(join(__dirname, "public"), { index: false }));
 }


### PR DESCRIPTION
- Improved build.sh with additional documentation.
- Adds support for http caching of static files with long expiration.
- Adds hash to bundled JS and CSS filenames to replace cached files on updates.
- Fixed: Consistent order of shop categories in main navigation